### PR TITLE
Use Knative Service for the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ CakePHP Sample App on OpenShift
 
 This is a quickstart CakePHP application for OpenShift v3 that you can use as a starting point to develop your own application and deploy it on an [OpenShift](https://github.com/openshift/origin) cluster.
 
-If you'd like to install it, follow [these directions](https://github.com/sclorg/cakephp-ex/blob/master/README.md#installation).  
+If you'd like to install it, follow [these directions](https://github.com/sclorg/cakephp-ex/blob/master/README.md#installation).
 
 The steps in this document assume that you have access to an OpenShift deployment that you can deploy applications on.
 
@@ -38,40 +38,40 @@ These steps assume your OpenShift deployment has the default set of ImageStreams
 
 1. Fork a copy of [cakephp-ex](https://github.com/sclorg/cakephp-ex)
 2. Clone your repository to your development machine and cd to the repository directory
-3. Add a PHP application from the provided template and specify the source url to be your forked repo  
+3. Add a PHP application from the provided template and specify the source url to be your forked repo
 
-		$ oc new-app openshift/templates/cakephp.json -p SOURCE_REPOSITORY_URL=<your repository location>
+		$ oc process -f openshift/templates/cakephp.json -p SOURCE_REPOSITORY_URL=<your repository location> | oc create -f -
 
 4. Depending on the state of your system, and whether additional items need to be downloaded, it may take around a minute for your build to be started automatically.  If you do not want to wait, run
 
 		$ oc start-build cakephp-example
 
-5. Once the build is running, watch your build progress  
+5. Once the build is running, watch your build progress
 
 		$ oc logs build/cakephp-example-1
 
-6. Wait for cakephp-example pods to start up (this can take a few minutes):  
+6. Wait for cakephp-example pods to start up (this can take a few minutes):
 
 		$ oc get pods -w
 
 
-	Sample output:  
+	Sample output:
 
 	       NAME                      READY     REASON         RESTARTS   AGE
 	       cakephp-example-1-build   0/1       ExitCode:0     0          8m
 	       cakephp-example-1-pytud   1/1       Running        0          2m
 
 
-7. Check the IP and port the cakephp-example service is running on:  
+7. Check the IP and port the cakephp-example service is running on:
 
 		$ oc get svc
 
-	Sample output:  
+	Sample output:
 
 	       NAME              LABELS                     SELECTOR               IP(S)           PORT(S)
 	       cakephp-example   template=cakephp-example   name=cakephp-example   172.30.97.123   8080/TCP
 
-In this case, the IP for cakephp-example is 172.30.97.123 and it is on port 8080.  
+In this case, the IP for cakephp-example is 172.30.97.123 and it is on port 8080.
 *Note*: you can also get this information from the web console.
 
 ### Debugging Unexpected Failures
@@ -79,9 +79,9 @@ In this case, the IP for cakephp-example is 172.30.97.123 and it is on port 8080
 Review some of the common tips and suggestions [here](https://github.com/openshift/origin/blob/master/docs/debugging-openshift.md).
 
 ### Installation: With MySQL
-1. Follow the steps for the Manual Installation above for all but step 3, instead use step 2 below.  
+1. Follow the steps for the Manual Installation above for all but step 3, instead use step 2 below.
   - Note: The output in steps 5-6 may also display information about your database.
-2. Add a PHP application from the cakephp-mysql template and specify the source url to be your forked repo  
+2. Add a PHP application from the cakephp-mysql template and specify the source url to be your forked repo
 
 		$ oc new-app openshift/templates/cakephp-mysql.json -p SOURCE_REPOSITORY_URL=<your repository location>
 
@@ -97,7 +97,7 @@ Since OpenShift V3 does not provide a git repository out of the box, you can con
 6. Navigate to your repository on GitHub and click on repository settings > webhooks > Add webhook
 7. Paste your webhook URL provided by OpenShift
 8. Leave the defaults for the remaining fields - That's it!
-9. After you save your webhook, if you refresh your settings page you can see the status of the ping that Github sent to OpenShift to verify it can reach the server.  
+9. After you save your webhook, if you refresh your settings page you can see the status of the ping that Github sent to OpenShift to verify it can reach the server.
 
 ### Enabling the Database example
 In order to access the example CakePHP home page, which contains application stats including database connectivity, you have to go into the app/View/Layouts/ directory, remove the default.ctp and after that rename default.ctp.default into default.ctp`.

--- a/openshift/templates/cakephp.json
+++ b/openshift/templates/cakephp.json
@@ -33,42 +33,6 @@
       }
     },
     {
-      "kind": "Service",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "${NAME}",
-        "annotations": {
-          "description": "Exposes and load balances the application pods"
-        }
-      },
-      "spec": {
-        "ports": [
-          {
-            "name": "web",
-            "port": 8080,
-            "targetPort": 8080
-          }
-        ],
-        "selector": {
-          "name": "${NAME}"
-        }
-      }
-    },
-    {
-      "kind": "Route",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "${NAME}"
-      },
-      "spec": {
-        "host": "${APPLICATION_DOMAIN}",
-        "to": {
-          "kind": "Service",
-          "name": "${NAME}"
-        }
-      }
-    },
-    {
       "kind": "ImageStream",
       "apiVersion": "v1",
       "metadata": {
@@ -139,8 +103,8 @@
       }
     },
     {
-      "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "kind": "Service",
+      "apiVersion": "serving.knative.dev/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
@@ -149,100 +113,68 @@
         }
       },
       "spec": {
-        "strategy": {
-          "type": "Rolling"
-        },
-        "triggers": [
-          {
-            "type": "ImageChange",
-            "imageChangeParams": {
-              "automatic": true,
-              "containerNames": [
-                "cakephp-example"
-              ],
-              "from": {
-                "kind": "ImageStreamTag",
-                "name": "${NAME}:latest"
-              }
-            }
-          },
-          {
-            "type": "ConfigChange"
-          }
-        ],
-        "replicas": 1,
-        "selector": {
-          "name": "${NAME}"
-        },
         "template": {
-          "metadata": {
-            "name": "${NAME}",
-            "labels": {
-              "name": "${NAME}"
-            }
-          },
-          "spec": {
-            "containers": [
-              {
-                "name": "cakephp-example",
-                "image": " ",
-                "ports": [
-                  {
-                    "containerPort": 8080
-                  }
-                ],
-                "readinessProbe": {
-                  "timeoutSeconds": 3,
-                  "initialDelaySeconds": 3,
-                  "periodSeconds": 60,
-                  "httpGet": {
-                    "path": "/",
-                    "port": 8080
-                  }
-                },
-                "livenessProbe": {
-                  "timeoutSeconds": 3,
-                  "initialDelaySeconds": 30,
-                  "periodSeconds": 60,
-                  "httpGet": {
-                    "path": "/",
-                    "port": 8080
-                  }
-                },
-                "env": [
-                  {
-                    "name": "CAKEPHP_SECRET_TOKEN",
-                    "valueFrom": {
-                      "secretKeyRef" : {
-                        "name" : "${NAME}",
-                        "key" : "cakephp-secret-token"
+            "spec": {
+                "containers": [
+                    {
+                        "name": "cakephp-example",
+                        "image": "image-registry.openshift-image-registry.svc:5000/example/${NAME}:latest",
+                        "ports": [
+                          {
+                            "containerPort": 8080
+                          }
+                        ],
+                        "readinessProbe": {
+                          "timeoutSeconds": 3,
+                          "initialDelaySeconds": 3,
+                          "failureThreshold": 3,
+                          "periodSeconds": 60,
+                          "httpGet": {
+                            "path": "/"
+                          }
+                        },
+                        "livenessProbe": {
+                          "timeoutSeconds": 3,
+                          "initialDelaySeconds": 30,
+                          "periodSeconds": 60,
+                          "httpGet": {
+                            "path": "/"
+                          }
+                        },
+                        "env": [
+                          {
+                            "name": "CAKEPHP_SECRET_TOKEN",
+                            "valueFrom": {
+                              "secretKeyRef" : {
+                                "name" : "${NAME}",
+                                "key" : "cakephp-secret-token"
+                              }
+                            }
+                          },
+                          {
+                            "name": "CAKEPHP_SECURITY_SALT",
+                            "valueFrom": {
+                              "secretKeyRef" : {
+                                "name" : "${NAME}",
+                                "key" : "cakephp-security-salt"
+                              }
+                            }
+                          },
+                          {
+                            "name": "OPCACHE_REVALIDATE_FREQ",
+                            "value": "${OPCACHE_REVALIDATE_FREQ}"
+                          }
+                        ],
+                        "resources": {
+                          "limits": {
+                            "memory": "${MEMORY_LIMIT}"
+                          }
+                        }
                       }
-                    }
-                  },
-                  {
-                    "name": "CAKEPHP_SECURITY_SALT",
-                    "valueFrom": {
-                      "secretKeyRef" : {
-                        "name" : "${NAME}",
-                        "key" : "cakephp-security-salt"
-                      }
-                    }
-                  },
-                  {
-                    "name": "OPCACHE_REVALIDATE_FREQ",
-                    "value": "${OPCACHE_REVALIDATE_FREQ}"
-                  }
-                ],
-                "resources": {
-                  "limits": {
-                    "memory": "${MEMORY_LIMIT}"
-                  }
+                    ]
                 }
-              }
-            ]
-          }
-        }
-      }
+            }
+         }
     }
   ],
   "parameters": [
@@ -290,12 +222,6 @@
       "name": "CONTEXT_DIR",
       "displayName": "Context Directory",
       "description": "Set this to the relative path to your project if it is not in the root of your repository."
-    },
-    {
-      "name": "APPLICATION_DOMAIN",
-      "displayName": "Application Hostname",
-      "description": "The exposed hostname that will route to the CakePHP service, if left blank a value will be defaulted.",
-      "value": ""
     },
     {
       "name": "GITHUB_WEBHOOK_SECRET",


### PR DESCRIPTION
This is a sample that demonstrates how to transforms a deployment of a Knative Service via a Template. For this example, we transformed the cake-php template that comes with the OpenShift installation and replaced the deployment with a `DeploymentConfig` to use a Knative `Service`.

The requirement to use the example in `openshift/templates/cakephp.json` is that you have OpenShift Serverless installed (tested with OCP 4.7 and OSS 1.14).

Steps to use this example is:

* Checkout the branch of this PR
* Perform the following steps:

```
# Create an example project
oc new-project example

# Process the template and apply it to the cluster
oc process -f openshift/templates/cakephp.json | oc create -f  -

# Start a build to create the image via S2I
oc start-build cakephp-example

# Watch the build to finish (adapt the build's name if needed)
oc logs -f build/cakephp-example-1 

# When finished check the status of the service with `kn` 
# (downloadable from the OpenShift console where the CLI tools can be downloaded)
kn service list

# Curl the service (or open the URL in the browser)
curl $(kn service describe cakephp-example -o url)
```

### Notes

* Check the diff of this PR to see what has been changed from the original `Template`
* You need to use `oc process` instead of `oc new-app` as the later only works with core OpenShift objects
* The general process to migrate a template to use Knative Services is
   - Replace any `Deployment` or `DeploymentConfig` in the template with a `Service` (and `serving.knative.dev/v1` as the API group)
   - Remove the OpenShift `Service` (that without Api group) and a `Route` as this is autocreated by default with OpenShift Serverless
   - You can use any template parameter as usual in the Knative Service declaration.
* The example used `ImageStream` triggers that does not yet work with OpenShift Serverless. Therefor the image is configured directly in the KService declaration and the deployment does not get updated when a new build is started/triggered. Support for change triggers is on the roadmap.